### PR TITLE
deps: Update to log4j 2.17.1 to resolve latest CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,13 +313,13 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.17.0</version>
+      <version>2.17.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.17.0</version>
+      <version>2.17.1</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Litelinks does not have a dependency on log4j but makes use of it in unit tests.