### PR TITLE
feat: Add "abort request" option for custom load balancers

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,4 +20,4 @@ jobs:
         java-version: '11'
         distribution: 'adopt'
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -e -B package --file pom.xml

--- a/src/main/java/com/ibm/watson/litelinks/client/CustomLoadBalancer.java
+++ b/src/main/java/com/ibm/watson/litelinks/client/CustomLoadBalancer.java
@@ -36,7 +36,7 @@ public abstract class CustomLoadBalancer implements LoadBalancer {
         @SuppressWarnings("rawtypes")
         public ListHolder(Object[] arr) {
             this.arr = arr;
-            this.list = (List<ServiceInstanceInfo>)(List)Collections.unmodifiableList(Arrays.asList(arr));
+            this.list = (List<ServiceInstanceInfo>)(List) Collections.unmodifiableList(Arrays.asList(arr));
         }
     }
 

--- a/src/main/java/com/ibm/watson/litelinks/client/LoadBalancer.java
+++ b/src/main/java/com/ibm/watson/litelinks/client/LoadBalancer.java
@@ -27,6 +27,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 @SuppressWarnings("unchecked")
 public interface LoadBalancer {
 
+    /**
+     * Can be returned from the {@link #getNext(Object[], String, Object[])} method of
+     * {@link LoadBalancingPolicy.InclusiveLoadBalancingPolicy non-inclusive} load balancer
+     * implementations instead of {@code null}, to reject all provided service instances and
+     * further instruct that no fallback attempt should be made against any currently
+     * failing instances (if applicable).
+     */
+    LitelinksServiceClient.ServiceInstanceInfo ABORT_REQUEST = ServiceInstanceCache.ABORT_REQUEST;
+
     <T> T getNext(Object[] list, String method, Object[] args);
 
     LoadBalancer RANDOM = new LoadBalancer() {

--- a/src/main/java/com/ibm/watson/litelinks/client/LoadBalancingPolicy.java
+++ b/src/main/java/com/ibm/watson/litelinks/client/LoadBalancingPolicy.java
@@ -39,24 +39,9 @@ package com.ibm.watson.litelinks.client;
 @FunctionalInterface
 public interface LoadBalancingPolicy {
 
-    LoadBalancingPolicy RANDOM = new InclusiveLoadBalancingPolicy() {
-        @Override
-        public LoadBalancer getLoadBalancer() {
-            return LoadBalancer.RANDOM;
-        }
-    },
-            ROUND_ROBIN = new InclusiveLoadBalancingPolicy() {
-                @Override
-                public LoadBalancer getLoadBalancer() {
-                    return new LoadBalancer.RoundRobin();
-                }
-            },
-            BALANCED = new InclusiveLoadBalancingPolicy() {
-                @Override
-                public LoadBalancer getLoadBalancer() {
-                    return LoadBalancer.BALANCED;
-                }
-            };
+    LoadBalancingPolicy RANDOM = (InclusiveLoadBalancingPolicy) () -> LoadBalancer.RANDOM;
+    LoadBalancingPolicy ROUND_ROBIN = (InclusiveLoadBalancingPolicy) LoadBalancer.RoundRobin::new;
+    LoadBalancingPolicy BALANCED = (InclusiveLoadBalancingPolicy) () -> LoadBalancer.BALANCED;
 
     /**
      * @return a {@link LoadBalancer} instance corresponding to this policy
@@ -69,6 +54,5 @@ public interface LoadBalancingPolicy {
      * all by returning null
      */
     @FunctionalInterface
-    interface InclusiveLoadBalancingPolicy extends LoadBalancingPolicy {
-    }
+    interface InclusiveLoadBalancingPolicy extends LoadBalancingPolicy {}
 }

--- a/src/main/java/com/ibm/watson/litelinks/client/ServiceInstanceCache.java
+++ b/src/main/java/com/ibm/watson/litelinks/client/ServiceInstanceCache.java
@@ -80,6 +80,7 @@ public final class ServiceInstanceCache<C> extends RegistryListener {
     // used as internal sentinel only
     @SuppressWarnings({ "unchecked", "rawtypes" })
     static final ServiceInstance<?> ALL_FAILING = new ServiceInstance(null, null, null, null);
+    static final ServiceInstance<?> ABORT_REQUEST = new ServiceInstance(null, null, null, null);
 
     @SuppressWarnings("rawtypes")
     private static final ServiceInstance[] EMPTYLIST = new ServiceInstance[0];

--- a/src/main/java/com/ibm/watson/litelinks/client/ServiceUnavailableException.java
+++ b/src/main/java/com/ibm/watson/litelinks/client/ServiceUnavailableException.java
@@ -19,8 +19,7 @@ public class ServiceUnavailableException extends Exception {
 
     private static final long serialVersionUID = -2885920148780929688L;
 
-    public ServiceUnavailableException() {
-    }
+    public ServiceUnavailableException() {}
 
     public ServiceUnavailableException(String message) {
         super(message);

--- a/src/main/java/com/ibm/watson/litelinks/client/TServiceClientManager.java
+++ b/src/main/java/com/ibm/watson/litelinks/client/TServiceClientManager.java
@@ -295,6 +295,9 @@ public class TServiceClientManager<C extends TServiceClient>
             if (si == ServiceInstanceCache.ALL_FAILING) {
                 throw new ServiceUnavailableException("all instances are failing: " + serviceName);
             }
+            if (si == ServiceInstanceCache.ABORT_REQUEST) {
+                throw new ServiceUnavailableException("request aborted by load balancer");
+            }
             try {
                 pc = si.borrowClient();
             } catch (IllegalStateException ise) {

--- a/src/test/java/com/ibm/watson/litelinks/test/LitelinksTests.java
+++ b/src/test/java/com/ibm/watson/litelinks/test/LitelinksTests.java
@@ -1708,7 +1708,7 @@ public class LitelinksTests {
 
                 returnFromLb[0] = LoadBalancer.ABORT_REQUEST; // reject all and don't fall back
 
-                // test "non-inclusive" loadbalancer function using LoadBalancer.NONE_AND_DONT_FALLBACK constant
+                // test "non-inclusive" loadbalancer function using LoadBalancer.ABORT_REQUEST constant
                 // should throw SUE despite cluster containing instances
                 try {
                     ilbClient.method_two(33, "", null);


### PR DESCRIPTION
#### Motivation

Litelinks supports custom client load balancing policies via the `LoadBalancer` and `LoadBalancingPolicy` interfaces. For a given `getNext(...)` call, an LB implementation may return null to reject all of the "offered" service instances. This is used in some cases to short-circuit the RPC request when the chosen service instance corresponds to the local process, so that a more efficient direct invocation can be made.

However, litelinks interprets the null return as "no suitable instances" from the "active" list and before returning from the client method call will first attempt sending to an instance on the "failing" list if it is non-empty.

#### Modifications

To allow the short-circuiting to work in cases that there are failing instances, we add a `NONE_AND_DONT_FALLBACK` constant to the `LoadBalancer` interface which can be returned as an alternative to null, but will instruct model-mesh to fail the request immediately rather than attempting to fall back to any failing instances.

Also extended unit test to cover the new feature and simplified some formatting in related classes.

#### Result

Custom load balancers have a reliable way to abort an RPC.