### PR TITLE
fix: Retry connection attempts after failed validation

### DIFF
--- a/src/main/java/com/ibm/watson/litelinks/client/TServiceClientManager.java
+++ b/src/main/java/com/ibm/watson/litelinks/client/TServiceClientManager.java
@@ -68,7 +68,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;

--- a/src/main/java/com/ibm/watson/litelinks/client/TServiceClientManager.java
+++ b/src/main/java/com/ibm/watson/litelinks/client/TServiceClientManager.java
@@ -56,8 +56,10 @@ import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.InterruptedIOException;
 import java.lang.reflect.Method;
 import java.net.SocketException;
+import java.nio.channels.InterruptedByTimeoutException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -298,9 +300,9 @@ public class TServiceClientManager<C extends TServiceClient>
                 pc = si.borrowClient();
             } catch (IllegalStateException ise) {
                 continue; // service inactive
-            } catch (TTransportException | SocketException | NoSuchElementException te) {
-                // NoSuchElementException is thrown if the pool's validation of the
-                // connection fails, which means that the connection's transport is not open.
+            } catch (InterruptedException | InterruptedIOException | InterruptedByTimeoutException ie) {
+                throw ie;
+            } catch (Exception te) { // Typically TTransportException, SocketException or NoSuchElementException
                 if (seen == null) {
                     seen = new HashSet<>();
                 }

--- a/src/main/java/com/ibm/watson/litelinks/client/TServiceClientManager.java
+++ b/src/main/java/com/ibm/watson/litelinks/client/TServiceClientManager.java
@@ -66,6 +66,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
@@ -297,11 +298,13 @@ public class TServiceClientManager<C extends TServiceClient>
                 pc = si.borrowClient();
             } catch (IllegalStateException ise) {
                 continue; // service inactive
-            } catch (TTransportException | SocketException te) {
+            } catch (TTransportException | SocketException | NoSuchElementException te) {
+                // NoSuchElementException is thrown if the pool's validation of the
+                // connection fails, which means that the connection's transport is not open.
                 if (seen == null) {
                     seen = new HashSet<>();
                 }
-                // don't try the same SI more than once
+                // don't try the same SI more than twice
                 // (won't happen before activeList has been exhausted)
                 if (!seen.add(si)) {
                     throw te;


### PR DESCRIPTION
#### Motivation

Some failures in unit tests are happening due to the client connection pool encountering "invalid" connections, which means the underlying channel isn't open. I'm not sure exactly how this happens but we should treat these errors like other transport errors when creating a connection and try to obtain another one rather than failing immediately.

#### Modification

When handling exceptions thrown by the connection pool's `borrowClient()` method, treat `NoSuchElementException` the same as transport/socket exceptions.

#### Result

Hopefully more resilient client behaviour and fixed test failures.
