### PR TITLE
Fixes  CVE-2025-24970

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <netty-version>4.1.73.Final</netty-version>
+    <netty-version>4.1.118.Final</netty-version>
   </properties>
 
   <build>


### PR DESCRIPTION
chore: Fix [CVE-2025-24970](https://github.com/advisories/GHSA-4g8c-wm8x-jfhw): SslHandler doesn't correctly validate packets which can lead to native crash when using native SSLEngine

#### Motivation


#### Modifications


#### Result
